### PR TITLE
Fix typo and wrong variable name for edge inference

### DIFF
--- a/edge/install-ec2-ubuntu-deps.sh
+++ b/edge/install-ec2-ubuntu-deps.sh
@@ -2,7 +2,7 @@
 sudo apt install cmake
 sudo apt install python3
 sudo apt install python3-pip
-audo apt install awscli
+sudo apt install awscli
 sudo apt install software-properties-common
 sudo add-apt-repository --yes ppa:deadsnakes/ppa
 sudo apt update

--- a/edge/sample-client-file-mqtt.py
+++ b/edge/sample-client-file-mqtt.py
@@ -75,7 +75,7 @@ print("Connected!")
 print('Begin Publish')
 data = "{} [{}]".format(str(messageToIotCore), 1)
 message = {"message": data,
-           "is_anomalous": response.detect_anomaly_result.is_anomalous}
+           "is_anomalous": detect_anomalies_response.detect_anomaly_result.is_anomalous}
 mqtt_connection.publish(topic=TOPIC, payload=json.dumps(
     message), qos=mqtt.QoS.AT_LEAST_ONCE)
 print("Published: '" + json.dumps(message) + "' to the topic: " + TOPIC)


### PR DESCRIPTION
*Description of changes:*
1. fix simple typo "audo" to "sudo" in shell script
2. fix inadequate variable "response" to "detect_anomalies_response" in inference script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
